### PR TITLE
[feature][extend_component_tests]: add component tests for Loader and CustomAlert, and fix eratic failures

### DIFF
--- a/cypress/components/atoms/Loader.atom.spec.cy.tsx
+++ b/cypress/components/atoms/Loader.atom.spec.cy.tsx
@@ -1,0 +1,25 @@
+import { mount } from "@cypress/react18";
+import { AppProvider } from "@/components/providers/AppProvider";
+import { Loader } from "@/components/atoms/Loader";
+
+const loaderSelector = "[data-cy=loader]";
+
+describe("1. Loader Component Tests", () => {
+  it("should display the loader when isLoading is true", () => {
+    mount(
+      <AppProvider>
+        <Loader isLoading={true} />
+      </AppProvider>,
+    );
+    cy.get(loaderSelector).should("be.visible");
+  });
+
+  it("2. should not display the loader when isLoading is false", () => {
+    mount(
+      <AppProvider>
+        <Loader isLoading={false} />
+      </AppProvider>,
+    );
+    cy.get("circle").should("not.exist");
+  });
+});

--- a/cypress/components/molecules/CustomAlert.molecule.spec.cy.tsx
+++ b/cypress/components/molecules/CustomAlert.molecule.spec.cy.tsx
@@ -1,0 +1,110 @@
+import { mount } from "@cypress/react18";
+import { AppProvider } from "@/components/providers/AppProvider";
+import CustomAlert from "@/components/molecules/CustomAlert/CustomAlert.molecule";
+import { AlertSeverity } from "@/components/molecules/CustomAlert/state/alert-model";
+
+const alertSelector = "[data-cy=alert]";
+const closeButtonSelector = `${alertSelector} button`;
+
+describe("CustomAlert Component Tests", () => {
+  it("1. should display the alert when isVisible is true", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={true}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+    cy.get(alertSelector).should("be.visible");
+  });
+
+  it("2. should hide the alert when isVisible is false", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={false}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+    cy.get(alertSelector).should("not.exist");
+  });
+
+  it("3. should close the alert when the close button is clicked", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={true}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+    cy.get(closeButtonSelector).click();
+
+    cy.get("@handleOnModalCloseMock").should("have.been.calledOnce");
+  });
+
+  it("4. should close the alert when the click away happens", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={true}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+
+    cy.get(".MuiBox-root").first().click();
+    cy.get("@handleOnModalCloseMock").should("have.been.calledOnce");
+  });
+
+  it("should apply the correct style based on severity", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={true}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+
+    cy.get(alertSelector).should("have.class", "MuiAlert-colorError");
+  });
+
+  it("should display the correct message", () => {
+    const handleOnModalCloseMock = cy.stub().as("handleOnModalCloseMock");
+
+    mount(
+      <AppProvider>
+        <CustomAlert
+          isVisible={true}
+          handleOnModalClose={handleOnModalCloseMock}
+          message="Expected Test Message"
+          severity={AlertSeverity.Error}
+        />
+      </AppProvider>,
+    );
+    cy.get(alertSelector).contains("Expected Test Message");
+  });
+});

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -19,21 +19,21 @@ import "./commands";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-import { mount } from "cypress/react18";
+// import { mount } from "@cypress/react18";
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.
 // Alternatively, can be defined in cypress/support/component.d.ts
 // with a <reference path="./component" /> at the top of your spec.
-declare global {
-  namespace Cypress {
-    interface Chainable {
-      mount: typeof mount;
-    }
-  }
-}
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       mount: typeof mount;
+//     }
+//   }
+// }
 
-Cypress.Commands.add("mount", mount);
+// Cypress.Commands.add("mount", mount);
 
 // Example use:
 // cy.mount(<MyComponent />)

--- a/src/components/atoms/Loader/Loader.atom.tsx
+++ b/src/components/atoms/Loader/Loader.atom.tsx
@@ -10,7 +10,7 @@ const _Loader: FC<LoaderProps> = ({ isLoading }) => {
   return (
     <>
       {isLoading && (
-        <StyledLoaderWrapper>
+        <StyledLoaderWrapper data-cy="loader">
           <CircularProgress color="inherit" />
         </StyledLoaderWrapper>
       )}


### PR DESCRIPTION
-  Add Loader and CustomAlert component tests
-  Comment out component support file mount references as temporary fix for erratic component test failures